### PR TITLE
 Fix problem using image_list and profile_list 

### DIFF
--- a/_modules/lxd.py
+++ b/_modules/lxd.py
@@ -1968,7 +1968,7 @@ def profile_list(list_names=False, remote_addr=None,
     if list_names:
         return [p.name for p in profiles]
 
-    return map(_pylxd_model_to_dict, profiles)
+    return [_pylxd_model_to_dict(i) for i in profiles]
 
 
 def profile_create(name, config=None, devices=None, description=None,
@@ -2549,7 +2549,7 @@ def image_list(list_aliases=False, remote_addr=None,
     if list_aliases:
         return {i.fingerprint: [a['name'] for a in i.aliases] for i in images}
 
-    return map(_pylxd_model_to_dict, images)
+    return [_pylxd_model_to_dict(i) for in in images]
 
 
 def image_get(fingerprint,

--- a/_modules/lxd.py
+++ b/_modules/lxd.py
@@ -2549,7 +2549,7 @@ def image_list(list_aliases=False, remote_addr=None,
     if list_aliases:
         return {i.fingerprint: [a['name'] for a in i.aliases] for i in images}
 
-    return [_pylxd_model_to_dict(i) for in in images]
+    return [_pylxd_model_to_dict(i) for i in images]
 
 
 def image_get(fingerprint,


### PR DESCRIPTION
Both  functions generated error:
Minion did not return. [No response]

But when using parameter list_names=True (profile_list) for list_aliases=True (image_list) it was working!

Could be related to the salt version I use: 2018.3.2 (Oxygen)
Note I use the same maser and minion version. 

Also note that on the minion it seems to use Python3 in my case (although Python2 is also installed).
As a result I also had to install Python3 version of pylxd (pip3 install -U pylxd). 
My pylxd==2.2.7
