### PR TITLE
refactor(pip): loosen pip logic & updated pillar example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Requirements
   you need Ubuntu.
 - This has been tested with Saltstack `2017.7.4`, we don't know if it
   works with other versions.
-- `PyLXD`_ version 2.2.5 from PIP (enable use_pip and it will get that version!).
+- `PyLXD`_ version 2.2.5 from PIP
 
 .. _PyLXD: https://github.com/lxc/pylxd
 .. _169: https://github.com/lxc/pylxd/pull/169
@@ -98,10 +98,6 @@ To not listen on the network and use the default storage engine:
       lxd:
         run_init: True
 
-      python:
-        # Currently pylxd version 2 is required for the lxd module to work.
-        use_pip: True
-
 To listen on the network:
 
 .. code-block:: yaml
@@ -115,10 +111,6 @@ To listen on the network:
           network_address: "[::]"
           network_port: "8443"
 
-
-      python:
-        # Currently pylxd version 2 is required for the lxd module to work.
-        use_pip: True
 
 Config examples
 +++++++++++++++
@@ -149,10 +141,6 @@ Config examples
             value: "[fd57:1:see:bad:c0de::14]:8443"
 
 
-      python:
-        # Currently pylxd version 2 is required for the lxd module to work.
-        use_pip: True
-
 
 ``lxd.client``
 --------------
@@ -163,7 +151,7 @@ Installs the lxd client - its a simple package installer for `lxd-client` (on De
 ``lxd.python``
 --------------
 
-Installs pylxd, this requires the `pip-formula`_ if you enable "use_pip".
+Installs pylxd, this requires the `pip-formula`_ if you enable "use_pip_formula".
 
 .. _pip-formula: https://github.com/saltstack-formulas/pip-formula
 

--- a/lxd/map.jinja
+++ b/lxd/map.jinja
@@ -22,6 +22,8 @@
       },
 
       'python': {
+        'use_pip': False,
+        'use_pip_formula': False,
         'packages': [
           'python-pylxd'
         ],

--- a/lxd/map.jinja
+++ b/lxd/map.jinja
@@ -22,7 +22,6 @@
       },
 
       'python': {
-        'use_pip': False,
         'use_pip_formula': False,
         'packages': [
           'python-pylxd'
@@ -66,7 +65,6 @@
   },
 
   'python': {
-    'use_pip': False,
     'use_pip_formula': False,
     'pip_package': {
       'action': 'installed',

--- a/lxd/python.sls
+++ b/lxd/python.sls
@@ -4,32 +4,24 @@
 
 {% from "lxd/map.jinja" import datamap, sls_block with context %}
 
-{% if datamap.python.use_pip or datamap.python.use_pip_formula %}
+{% if datamap.python.use_pip_formula %}
 include:
   - pip
   - pip.extensions
 {% endif %}
 
-{% if datamap.python.use_pip or datamap.python.use_pip_formula %}
 lxd_python_pip:
   pkg:
     - {{ datamap.python.pip_package.action }}
     {{ sls_block(datamap.python.pip_package.opts )}}
     - pkgs: {{ datamap.lookup.python.pip_packages }}
-{% endif %}
 
 lxd_python:
   pkg:
-    {% if datamap.python.use_pip or datamap.python.use_pip_formula %}
-    - removed
-    {% else %}
     - {{ datamap.python.package.action }}
-    {% endif %}
     {{ sls_block(datamap.python.package.opts )}}
     - pkgs: {{ datamap.lookup.python.packages }}
     - reload_modules: True
-
-  {% if datamap.python.use_pip or datamap.python.use_pip_formula %}
   pip:
     - {{ datamap.python.pip_package.action }}
     {% if datamap.python.get('pip_version') %}
@@ -40,4 +32,3 @@ lxd_python:
     - reload_modules: True
     - require:
       - pkg: lxd_python_pip
-  {% endif %}

--- a/pillar.example.yaml
+++ b/pillar.example.yaml
@@ -51,7 +51,6 @@ lxd:
             nictype: macvlan
             parent: eth1
             type: nic
-  #python: {use_pip: true}
   #remotes:
   #  local: {cert: /root/.config/lxc/client.crt, key: /root/.config/lxc/client.key,
   #    password: PassW0rd, remote_addr: 'https://srv03:8443', type: lxd, verify_cert: false}

--- a/pillar.example.yaml
+++ b/pillar.example.yaml
@@ -1,4 +1,8 @@
 lxd:
+  lookup:
+    python:
+      packages:
+        - python3-pip
   containers:
     local:
       bootstraptest:
@@ -44,10 +48,10 @@ lxd:
       default:
         devices:
           eth0:
-            nictype: bridged
-            parent: lanbr0
+            nictype: macvlan
+            parent: eth1
             type: nic
-  python: {use_pip: true}
-  remotes:
-    local: {cert: /root/.config/lxc/client.crt, key: /root/.config/lxc/client.key,
-      password: PassW0rd, remote_addr: 'https://srv03:8443', type: lxd, verify_cert: false}
+  #python: {use_pip: true}
+  #remotes:
+  #  local: {cert: /root/.config/lxc/client.crt, key: /root/.config/lxc/client.key,
+  #    password: PassW0rd, remote_addr: 'https://srv03:8443', type: lxd, verify_cert: false}


### PR DESCRIPTION
This PR is an improvement for first time users of lxd.

If `use_pip` or `use_pip_formula` are set then some errors can happen-

1.  Error `SLS pip / pip.extensions not found` - there is hard dependency on pip-formula.
2. Error ` State 'lxd.init' was not found in SLS 'lxd.lxd'` because 
       - `pylxd` pip package is not installed
       - `pylxd` pip package was installed by wrong pip binary
       -  combination of these

And  it's not easy to setup default profile

a. Errors `LXDAPIException: Common start logic: ......` because new users are dumb ;=)
b.  Using`nictype: macvlan` worked best for during basic testing.

This PR was verified on Ubuntu 18.04 with updated `pillar.example`. 
All states passed finally.