### PR TITLE
profile config is not properly serialized

### DIFF
--- a/lxd/containers.sls
+++ b/lxd/containers.sls
@@ -30,7 +30,7 @@ lxd_container_{{ remotename }}_{{ name }}:
     - profiles: {{ container.profiles }}
     {%- endif %}
     {%- if 'config' in container %}
-    - config: {{ container.config }}
+    - config: {{ container.config | tojson }}
     {%- endif %}
     {%- if 'devices' in container %}
     - devices: {{ container.devices }}

--- a/lxd/profiles.sls
+++ b/lxd/profiles.sls
@@ -28,7 +28,7 @@ lxd_profile_{{ remotename }}_{{ name }}:
     - description: "{{ profile.description }}"
         {%- endif %}
         {%- if profile.get('config', False) %}
-    - config: {{ profile.config }}
+    - config: {{ profile.config | tojson }}
         {%- endif %}
         {%- if profile.get('devices', False) %}
     - devices: {{ profile.devices }}


### PR DESCRIPTION
## Bug details
lxd.profiles and lxd.containers don't properly escape config values.

### Steps to reproduce the bug

```
pillars:
  lxd:
    profiles:
      local:
        my_profile:
          config:
            user.user-data: |
              #cloud-config
              ssh_authorized_keys:
                - "ssh-rsa AAAA..."
```
Then run state.highstate
You'll get something like this
```
$ lxc profile show my_profile
config:
  user.user-data: '#cloud-config\nssh_authorized_keys:\n  - "ssh-rsa AAAA..."'
```
At first glance the config looks equivalent, but the escaped newlines are single-quoted, which means they will not get reinterpreted as newlines.

### Expected behaviour
```
$ lxc profile show my_profile
config:
  user.user-data: |
    #cloud-config
    ssh_authorized_keys:
      - "ssh-rsa AAAA..."
```